### PR TITLE
Update form handling for cleaner responses

### DIFF
--- a/FormManager.js
+++ b/FormManager.js
@@ -201,11 +201,11 @@ Thank you for your interest in our community!
         .setHelpText('Upload recent pay stub, bank statement, or employment letter (PDF, JPG, PNG)')
         .setFolderName('Belvedere White House Rental - Applications');
     } else {
-      // Fallback for personal accounts where file uploads are not supported
+      // Fallback when file uploads are unavailable
       form.addParagraphTextItem()
-        .setTitle('Proof of Income (Link) *')
+        .setTitle('Proof of Income *')
         .setRequired(true)
-        .setHelpText('Provide a link to a proof of income document in Google Drive or other cloud storage');
+        .setHelpText('Describe or link your proof of income document');
     }
     
     // Agreement
@@ -221,8 +221,14 @@ Thank you for your interest in our community!
     form.setDestination(FormApp.DestinationType.SPREADSHEET, SpreadsheetApp.getActiveSpreadsheet().getId());
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const respSheetName = form.getTitle() + ' (Responses)';
-    const respSheet = ss.getSheetByName(respSheetName);
-    if (respSheet) respSheet.setName(CONFIG.SHEETS.APPLICATIONS);
+    let respSheet = ss.getSheetByName(respSheetName);
+    if (!respSheet) {
+      respSheet = ss.getSheets().find(s => /^Form Responses/.test(s.getName()));
+    }
+    if (respSheet) {
+      respSheet.setName(CONFIG.SHEETS.APPLICATIONS);
+      SheetManager.cleanHeaderAsterisks(respSheet);
+    }
 
     return form;
   },
@@ -340,8 +346,14 @@ Thank you for being a valued resident!
     form.setDestination(FormApp.DestinationType.SPREADSHEET, SpreadsheetApp.getActiveSpreadsheet().getId());
     const ss = SpreadsheetApp.getActiveSpreadsheet();
     const respName = form.getTitle() + ' (Responses)';
-    const responseSheet = ss.getSheetByName(respName);
-    if (responseSheet) responseSheet.setName(CONFIG.SHEETS.MOVEOUTS);
+    let responseSheet = ss.getSheetByName(respName);
+    if (!responseSheet) {
+      responseSheet = ss.getSheets().find(s => /^Form Responses/.test(s.getName()));
+    }
+    if (responseSheet) {
+      responseSheet.setName(CONFIG.SHEETS.MOVEOUTS);
+      SheetManager.cleanHeaderAsterisks(responseSheet);
+    }
 
     return form;
   },

--- a/SheetManager.js
+++ b/SheetManager.js
@@ -635,6 +635,18 @@ const SheetManager = {
     
     return sheet.getRange(startRow, 1, numRows, sheet.getLastColumn()).getValues();
   },
+
+  /**
+   * Remove asterisks from header row of a sheet
+   */
+  cleanHeaderAsterisks: function(sheet) {
+    const lastColumn = sheet.getLastColumn();
+    if (lastColumn === 0) return;
+    const range = sheet.getRange(1, 1, 1, lastColumn);
+    const headers = range.getValues()[0];
+    const cleaned = headers.map(h => (typeof h === 'string') ? h.replace(/\s*\*+$/, '').trim() : h);
+    range.setValues([cleaned]);
+  },
   
   /**
    * Clear sheet data (keep headers)


### PR DESCRIPTION
## Summary
- ensure proof of income defaults to file upload and fallbacks use a paragraph field
- automatically rename response sheets and strip asterisks from headers
- helper added in `SheetManager` to clean header text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6887c04e6f288322b6163218a4f8fdcf