### PR TITLE
Apply sheet formatting after adding sample data

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -715,6 +715,8 @@ function initializeCompleteSystem() {
     DataManager.createSampleData();
     DataManager.createSampleGuestBookings();
     DataManager.createSampleMaintenanceRequests();
+    // Reapply formatting so dropdowns and other validations are added
+    SheetManager.applySheetSpecificFormatting(SpreadsheetApp.getActiveSpreadsheet());
     
     ui.alert(
       'System Initialized Successfully!',


### PR DESCRIPTION
## Summary
- reapply sheet-specific formatting after inserting sample data
  - ensures dropdowns like *Room Status* and *Payment Status* are created when the system is initialized

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887c1fde72083229db251bd3b9089f2