### PR TITLE
Add dropdowns from sample data

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -717,6 +717,7 @@ function initializeCompleteSystem() {
     DataManager.createSampleMaintenanceRequests();
     // Reapply formatting so dropdowns and other validations are added
     SheetManager.applySheetSpecificFormatting(SpreadsheetApp.getActiveSpreadsheet());
+    SpreadsheetApp.flush();
     
     ui.alert(
       'System Initialized Successfully!',


### PR DESCRIPTION
## Summary
- add efficient row banding in tenant sheet
- auto-create dropdown validations for budget and maintenance sheets
- expose helper to gather unique column values
- flush formatting changes during initialization

## Testing
- `node -e "require('./SheetManager.js')"` *(fails: Logger is not defined)*
- `node -e "require('./Main.js')"` *(fails: Session is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6887c67263bc8322852ed9e97b0b81a2