### PR TITLE
Centralized financial dashboard

### DIFF
--- a/FinancialManager.js
+++ b/FinancialManager.js
@@ -1091,6 +1091,143 @@ const FinancialManager = {
     } catch (error) {
       handleSystemError(error, 'exportTaxData');
     }
+  },
+
+  /**
+   * Show consolidated financial dashboard
+   */
+  showFinancialDashboard: function() {
+    try {
+      const now = new Date();
+      const data = SheetManager.getAllData(CONFIG.SHEETS.BUDGET);
+
+      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+      const yearStart = new Date(now.getFullYear(), 0, 1);
+
+      const monthAnalysis = this.analyzeFinancialData(data, monthStart, now);
+      const yearAnalysis = this.analyzeFinancialData(data, yearStart, now);
+
+      const occupancyStats = this.calculateOccupancyStats(
+        SheetManager.getAllData(CONFIG.SHEETS.TENANTS),
+        SheetManager.getAllData(CONFIG.SHEETS.GUEST_ROOMS),
+        SheetManager.getAllData(CONFIG.SHEETS.GUEST_BOOKINGS)
+      );
+
+      const profitMetrics = this.calculateProfitabilityMetrics(data, monthStart, now);
+
+      const html = HtmlService.createHtmlOutput(`
+        <style>
+          .fh-tab{display:none;}
+          .fh-tab.active{display:block;}
+          .fh-tabs button{margin-right:5px;}
+        </style>
+        <div style="font-family: Arial, sans-serif; padding:20px;">
+          <div class="fh-tabs">
+            <button onclick="fhShow('overview')">Overview</button>
+            <button onclick="fhShow('revenue')">Revenue</button>
+            <button onclick="fhShow('occupancy')">Occupancy</button>
+            <button onclick="fhShow('profit')">Profitability</button>
+          </div>
+
+          <div id="overview" class="fh-tab active">
+            <h3>Monthly Overview</h3>
+            <p><strong>Total Income:</strong> ${Utils.formatCurrency(monthAnalysis.totalIncome)}</p>
+            <p><strong>Total Expenses:</strong> ${Utils.formatCurrency(monthAnalysis.totalExpenses)}</p>
+            <p><strong>Net Profit:</strong> ${Utils.formatCurrency(monthAnalysis.netProfit)}</p>
+          </div>
+
+          <div id="revenue" class="fh-tab">
+            <h3>Year to Date Revenue</h3>
+            ${Object.entries(yearAnalysis.incomeByCategory).map(([c,a])=>`<div>${c}: ${Utils.formatCurrency(a)}</div>`).join('')}
+          </div>
+
+          <div id="occupancy" class="fh-tab">
+            <h3>Current Occupancy</h3>
+            <p>Overall: ${occupancyStats.overallOccupancy}% (${occupancyStats.totalOccupied}/${occupancyStats.totalRooms})</p>
+            <p>Tenants: ${occupancyStats.tenantOccupancy}%</p>
+            <p>Guests: ${occupancyStats.guestOccupancy}%</p>
+          </div>
+
+          <div id="profit" class="fh-tab">
+            <h3>Profitability This Month</h3>
+            <p>Net Profit: ${Utils.formatCurrency(profitMetrics.netProfit)}</p>
+            <p>Margin: ${profitMetrics.profitMargin}%</p>
+          </div>
+
+          <script>
+            function fhShow(id){
+              document.querySelectorAll('.fh-tab').forEach(t=>t.classList.remove('active'));
+              document.getElementById(id).classList.add('active');
+            }
+          </script>
+        </div>
+      `).setWidth(600).setHeight(500);
+
+      SpreadsheetApp.getUi().showModalDialog(html, 'Financial Dashboard');
+    } catch (error) {
+      handleSystemError(error, 'showFinancialDashboard');
+    }
+  },
+
+  /**
+   * Show unified export options
+   */
+  showExportOptions: function() {
+    const html = HtmlService.createHtmlOutput(`
+      <div style="font-family: Arial, sans-serif; padding:20px;">
+        <h3>Export Financial Data</h3>
+        <p>
+          <button onclick="google.script.run.exportFinancialData()">Full CSV</button>
+          <button onclick="google.script.run.exportTaxData()">Current Tax Year</button>
+        </p>
+        <p>Custom Range:</p>
+        <p>
+          <input type="date" id="start"> to
+          <input type="date" id="end">
+          <button onclick="exportRange()">Export</button>
+        </p>
+        <script>
+          function exportRange(){
+            const s=document.getElementById('start').value;
+            const e=document.getElementById('end').value;
+            google.script.run.exportFinancialDataRange(s,e);
+          }
+        </script>
+      </div>
+    `).setWidth(400).setHeight(220);
+    SpreadsheetApp.getUi().showModalDialog(html, 'Export Options');
+  },
+
+  /**
+   * Export financial data within a custom range
+   */
+  exportFinancialDataRange: function(start, end) {
+    try {
+      const startDate = new Date(start);
+      const endDate = new Date(end);
+
+      const data = SheetManager.getAllData(CONFIG.SHEETS.BUDGET, true);
+      const filtered = [data[0]];
+      for (let i=1; i<data.length; i++) {
+        const row = data[i];
+        const d = new Date(row[this.COL.DATE - 1]);
+        if (d >= startDate && d <= endDate) filtered.push(row);
+      }
+
+      const csvContent = filtered.map(row => row.map(cell => {
+        if (cell instanceof Date) return Utils.formatDate(cell, 'yyyy-MM-dd');
+        if (typeof cell === 'string' && cell.includes(',')) return `"${cell}"`;
+        return cell;
+      }).join(',')).join('\n');
+
+      const fileName = `FinancialData_${Utils.formatDate(startDate,'yyyyMMdd')}_${Utils.formatDate(endDate,'yyyyMMdd')}.csv`;
+      const blob = Utilities.newBlob(csvContent, 'text/csv', fileName);
+      DriveApp.createFile(blob);
+
+      SpreadsheetApp.getUi().alert('Export complete: '+fileName);
+    } catch (error) {
+      handleSystemError(error, 'exportFinancialDataRange');
+    }
   }
 };
 

--- a/Main.js
+++ b/Main.js
@@ -661,11 +661,8 @@ function onOpen() {
       .addItem('💰 Maintenance Cost Report', 'generateMaintenanceCostReport'))
     
     .addSubMenu(ui.createMenu('📊 Financial Reports')
-      .addItem('💰 Monthly Financial Report', 'generateMonthlyFinancialReport')
-      .addItem('📈 Revenue Analysis', 'showRevenueAnalysis')
-      .addItem('🏠 Occupancy Analytics', 'showOccupancyAnalytics')
-      .addItem('💡 Profitability Dashboard', 'showProfitabilityDashboard')
-      .addItem('📋 Tax Report', 'generateTaxReport'))
+      .addItem('📊 Financial Dashboard', 'showFinancialDashboard')
+      .addItem('📥 Export Data', 'showExportOptions'))
     
     .addSubMenu(ui.createMenu('📋 Forms & Documents')
       .addItem('🏗️ Create All Forms', 'createAllSystemForms')
@@ -1076,6 +1073,8 @@ function showOccupancyAnalytics() { FinancialManager.showOccupancyAnalytics(); }
 function showProfitabilityDashboard() { FinancialManager.showProfitabilityDashboard(); }
 function generateTaxReport() { FinancialManager.generateTaxReport(); }
 function exportFinancialData() { FinancialManager.exportFinancialData(); }
+function showFinancialDashboard() { FinancialManager.showFinancialDashboard(); }
+function showExportOptions() { FinancialManager.showExportOptions(); }
 
 // Initialize system when script loads
 Logger.log('Parsonage Management System v2.0 loaded successfully');


### PR DESCRIPTION
## Summary
- add unified Financial Dashboard with tabs for revenue, occupancy and profit
- provide export options for full CSV, tax year and custom range
- simplify menu to use the new dashboard and export dialog

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887d186c2248322bf22f35ca226b59d