### PR TITLE
Centralized financial dashboard

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -661,11 +661,8 @@ function onOpen() {
       .addItem('💰 Maintenance Cost Report', 'generateMaintenanceCostReport'))
     
     .addSubMenu(ui.createMenu('📊 Financial Reports')
-      .addItem('💰 Monthly Financial Report', 'generateMonthlyFinancialReport')
-      .addItem('📈 Revenue Analysis', 'showRevenueAnalysis')
-      .addItem('🏠 Occupancy Analytics', 'showOccupancyAnalytics')
-      .addItem('💡 Profitability Dashboard', 'showProfitabilityDashboard')
-      .addItem('📋 Tax Report', 'generateTaxReport'))
+      .addItem('📊 Financial Dashboard', 'showFinancialDashboard')
+      .addItem('📥 Export Data', 'showExportOptions'))
     
     .addSubMenu(ui.createMenu('📋 Forms & Documents')
       .addItem('🏗️ Create All Forms', 'createAllSystemForms')
@@ -1076,6 +1073,8 @@ function showOccupancyAnalytics() { FinancialManager.showOccupancyAnalytics(); }
 function showProfitabilityDashboard() { FinancialManager.showProfitabilityDashboard(); }
 function generateTaxReport() { FinancialManager.generateTaxReport(); }
 function exportFinancialData() { FinancialManager.exportFinancialData(); }
+function showFinancialDashboard() { FinancialManager.showFinancialDashboard(); }
+function showExportOptions() { FinancialManager.showExportOptions(); }
 
 // Initialize system when script loads
 Logger.log('Parsonage Management System v2.0 loaded successfully');


### PR DESCRIPTION
## Summary
- centralize financial calculations in `gatherDashboardData`
- add `buildMonthlySection`, `buildRevenueSection`, `buildOccupancySection`, `buildProfitSection`
- overhaul `showFinancialDashboard` with tabbed view and export button
- keep export options dialog for CSV, tax year or range

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887d186c2248322bf22f35ca226b59d