### PR TITLE
Fix syntax in TenantManager modal

### DIFF
--- a/TenantManager.js
+++ b/TenantManager.js
@@ -591,6 +591,7 @@ const TenantManager = {
 
       const options = tenants.map((t, i) => `<option value="${i}">${t.name}</option>`).join('');
 
+      const html = HtmlService.createHtmlOutput(`
 <div class="container">
   <h3>Process Tenant Move-Out</h3>
   <form id="moveOutForm">


### PR DESCRIPTION
## Summary
- fix missing HtmlService.createHtmlOutput call when processing tenant move-out

## Testing
- `node --check TenantManager.js`
- `for f in *.js; do node --check "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_688a3f29167c8322a4ccd331798b6453