### PR TITLE
Add manual budget entry feature

### DIFF
--- a/Main.js
+++ b/Main.js
@@ -775,6 +775,7 @@ function onOpen() {
     
     .addSubMenu(ui.createMenu('📊 Financial Reports')
       .addItem('📊 Financial Dashboard', 'showFinancialDashboard')
+      .addItem('➕ Add Budget Entry', 'showAddBudgetEntryPanel')
       .addItem('📥 Export Data', 'showExportOptions'))
     
     .addSubMenu(ui.createMenu('📋 Forms & Documents')
@@ -1189,6 +1190,8 @@ function generateTaxReport() { FinancialManager.generateTaxReport(); }
 function exportFinancialData() { FinancialManager.exportFinancialData(); }
 function showFinancialDashboard() { FinancialManager.showFinancialDashboard(); }
 function showExportOptions() { FinancialManager.showExportOptions(); }
+function showAddBudgetEntryPanel() { FinancialManager.showAddBudgetEntryPanel(); }
+function addBudgetEntry(data) { FinancialManager.addBudgetEntry(data); }
 
 // Initialize system when script loads
 Logger.log('Parsonage Management System v2.0 loaded successfully');


### PR DESCRIPTION
## Summary
- expose menu option for adding manual budget entries
- implement UI and logic for manual budget entries in FinancialManager
- wrap new financial methods in `Main.js`

## Testing
- `node -c FinancialManager.js`
- `node -c Main.js`


------
https://chatgpt.com/codex/tasks/task_e_688bae505414832287edd6681cb3dff6